### PR TITLE
Kill httparty dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
-OxfordDictionary 1.0.0 (master, unreleased)
+## OxfordDictionary 1.0.0 (master, unreleased)
+
+- Remove httparty as a runtime dependency
+  [\#1](https://github.com/swcraig/oxford-dictionary/pull/1)
+
 

--- a/lib/oxford_dictionary/request.rb
+++ b/lib/oxford_dictionary/request.rb
@@ -1,4 +1,3 @@
-require 'httparty'
 require 'json'
 require 'net/http'
 require 'plissken'
@@ -7,8 +6,6 @@ require 'oxford_dictionary/error'
 module OxfordDictionary
   # Handles all of the actual API calls
   module Request
-    include HTTParty
-
     BASE = 'https://od-api.oxforddictionaries.com/api/v1'.freeze
     HTTP_OK = '200'.freeze
     ACCEPT_TYPE = 'application/json'.freeze

--- a/oxford_dictionary.gemspec
+++ b/oxford_dictionary.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 2.1.0'
   spec.add_development_dependency 'rubocop', '~> 0.45.0'
 
-  spec.add_runtime_dependency 'httparty', '~> 0.14.0'
   spec.add_runtime_dependency 'virtus', '~> 1.0.5'
   spec.add_runtime_dependency 'plissken', '~> 0.1.0'
 end


### PR DESCRIPTION
Use Ruby's net/http library instead. This way users won't need to have httparty as an unnecessary runtime dependency in their applications. 