### PR TITLE
client.word_frequency endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ inflections = client.inflection('changed')
 # Wordlist results (based on categorys, filters, etc...)
 related = client.wordlist(lexicalCategory: 'Noun', word_length: '>5,<10')
 
+# Word frequency results
+related = client.word_frequency(lemma: 'spring', lexicalCategory: 'Noun')
+
 # Or the search endpoint
 search_results = client.search('condition', prefix: true)
 ```

--- a/lib/oxford_dictionary/api_objects/word_frequency_response.rb
+++ b/lib/oxford_dictionary/api_objects/word_frequency_response.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'virtus'
+
+class WordFrequencyResponse
+  class Metadata
+    class Options
+      include Virtus.model
+      attribute :corpus, String
+      attribute :lemma, String
+    end
+
+    include Virtus.model
+    attribute :language, String
+    attribute :options, WordFrequencyResponse::Metadata::Options
+  end
+
+  class Result
+    include Virtus.model
+    attribute :frequency, Integer
+    attribute :lemma, String
+    attribute :match_count, Integer
+    attribute :normalized_frequency, Float
+  end
+
+  include Virtus.model
+  attribute :metadata, WordFrequencyResponse::Metadata
+  attribute :result, WordFrequencyResponse::Result
+end

--- a/lib/oxford_dictionary/client.rb
+++ b/lib/oxford_dictionary/client.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 require 'oxford_dictionary/endpoints/entry_endpoint'
 require 'oxford_dictionary/endpoints/inflection_endpoint'
 require 'oxford_dictionary/endpoints/search_endpoint'
 require 'oxford_dictionary/endpoints/wordlist_endpoint'
+require 'oxford_dictionary/endpoints/word_frequency_endpoint'
 
 module OxfordDictionary
   # The client object to interact with
@@ -10,6 +13,7 @@ module OxfordDictionary
     include OxfordDictionary::Endpoints::InflectionEndpoint
     include OxfordDictionary::Endpoints::SearchEndpoint
     include OxfordDictionary::Endpoints::WordlistEndpoint
+    include OxfordDictionary::Endpoints::WordFrequencyEndpoint
 
     attr_reader :app_id, :app_key
 
@@ -17,6 +21,7 @@ module OxfordDictionary
       unless params.is_a?(Hash) && params.key?(:app_id) && params.key?(:app_key)
         raise(ArgumentError, 'API id and key required.')
       end
+
       params.each do |key, value|
         instance_variable_set("@#{key}", value)
       end

--- a/lib/oxford_dictionary/endpoints/word_frequency_endpoint.rb
+++ b/lib/oxford_dictionary/endpoints/word_frequency_endpoint.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'oxford_dictionary/request'
+require 'oxford_dictionary/api_objects/word_frequency_response'
+
+module OxfordDictionary
+  module Endpoints
+    # Interface to 'stats/frequency/word' endpoint
+    module WordFrequencyEndpoint
+      include OxfordDictionary::Request
+      ENDPOINT = 'stats/frequency/word'
+
+      def word_frequency(params = {})
+        WordFrequencyResponse.new(request(ENDPOINT, nil, params))
+      end
+    end
+  end
+end

--- a/spec/endpoint_specs/word_frequency_endpoint_spec.rb
+++ b/spec/endpoint_specs/word_frequency_endpoint_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OxfordDictionary::Endpoints::WordFrequencyEndpoint do
+  before do
+    stub_get(
+      'stats/frequency/word/en/lemma=spring',
+      'word_frequency_spring.json',
+    )
+    stub_get(
+      'stats/frequency/word/en/lemma=spring;lexicalCategory=noun',
+      'word_frequency_spring_noun.json',
+    )
+    stub_get(
+      'stats/frequency/word/en/lemma=spring;lexicalCategory=verb',
+      'word_frequency_spring_verb.json',
+    )
+  end
+
+  let(:client) { OxfordDictionary.new(app_id: 'ID', app_key: 'SECRET') }
+
+  context '#word_frequency with lemma' do
+    let(:resp) { client.word_frequency(lemma: 'spring') }
+
+    it 'it has metadata' do
+      metadata = resp.metadata
+      expect(metadata.language).to eq('en')
+      expect(metadata.options.lemma).to eq('spring')
+    end
+
+    it 'has result' do
+      result = resp.result
+      expect(result.frequency).to be_an Integer
+      expect(result.lemma).to eq('spring')
+      expect(result.match_count).to be_an Integer
+      expect(result.normalized_frequency).to be_a Float
+    end
+  end
+
+  context '#word_frequency with lemma and lexicalCategory' do
+    let(:resp) { client.word_frequency(lemma: 'spring') }
+
+    it 'it has metadata' do
+      metadata = resp.metadata
+      expect(metadata.language).to eq('en')
+      expect(metadata.options.lemma).to eq('spring')
+    end
+
+    it 'has result' do
+      result = resp.result
+      expect(result.frequency).to be_an Integer
+      expect(result.lemma).to eq('spring')
+      expect(result.match_count).to be_an Integer
+      expect(result.normalized_frequency).to be_a Float
+    end
+  end
+end

--- a/spec/fixtures/word_frequency_spring.json
+++ b/spec/fixtures/word_frequency_spring.json
@@ -1,0 +1,16 @@
+{
+  "metadata": {
+    "language": "en",
+    "options": {
+      "corpus": "nmc",
+      "lemma": "spring"
+    },
+    "provider": "Oxford University Press"
+  },
+  "result": {
+    "frequency": 522812,
+    "lemma": "spring",
+    "matchCount": 37,
+    "normalizedFrequency": 57.3541878552803
+  }
+}

--- a/spec/fixtures/word_frequency_spring_noun.json
+++ b/spec/fixtures/word_frequency_spring_noun.json
@@ -1,0 +1,18 @@
+{
+    "metadata": {
+        "language": "en",
+        "options": {
+            "corpus": "nmc",
+            "lemma": "spring",
+            "lexicalCategory": "noun"
+        },
+        "provider": "Oxford University Press"
+    },
+    "result": {
+        "frequency": 454602,
+        "lemma": "spring",
+        "lexicalCategory": "noun",
+        "matchCount": 5,
+        "normalizedFrequency": 49.8713275659054
+    }
+}


### PR DESCRIPTION
https://developer.oxforddictionaries.com/documentation

```
/stats/frequency/word/{source_lang}/
```

This endpoint provides the frequency of a given word. When multiple database records match the query parameters, the returned frequency is the sum of the individual frequencies. For example, if the query parameters are lemma=test, the returned frequency will include the verb "test", the noun "test" and the adjective "test" in all forms (Test, tested, testing, etc.) 
