### PR TITLE
Deprecate Wordlist endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## OxfordDictionary master (unreleased)
 
+- Deprecate the Wordlist endpoint
+  [\#5](https://github.com/swcraig/oxford-dictionary/pull/5)
+
 ## OxfordDictionary 1.0.0 (2017-09-19)
 
 - Remove httparty as a runtime dependency

--- a/lib/oxford_dictionary/endpoints/wordlist_endpoint.rb
+++ b/lib/oxford_dictionary/endpoints/wordlist_endpoint.rb
@@ -6,6 +6,8 @@ module OxfordDictionary
     # Interface to '/wordlist' endpoint
     module WordlistEndpoint
       include OxfordDictionary::Request
+      extend Gem::Deprecate
+
       ENDPOINT = 'wordlist'.freeze
       ADVANCED_FILTERS = [:exact, :exclude, :exclude_senses,
                           :exclude_prime_senses, :limit, :offset,
@@ -18,6 +20,7 @@ module OxfordDictionary
         end
         ListResponse.new(request(ENDPOINT, nil, params))
       end
+      deprecate :wordlist, :none, 2019, 6
 
       private
 


### PR DESCRIPTION
Oxford Dictionaries is removing the wordlist endpoint in the upcoming
version 2 update:
https://developer.oxforddictionaries.com/version2