### PR TITLE
Rename Request to DeprecatedRequest

### DIFF
--- a/lib/oxford_dictionary/deprecated_request.rb
+++ b/lib/oxford_dictionary/deprecated_request.rb
@@ -5,7 +5,7 @@ require 'oxford_dictionary/error'
 
 module OxfordDictionary
   # Handles all of the actual API calls
-  module Request
+  module DeprecatedRequest
     BASE = 'https://od-api.oxforddictionaries.com/api/v1'.freeze
     HTTP_OK = '200'.freeze
     ACCEPT_TYPE = 'application/json'.freeze

--- a/lib/oxford_dictionary/endpoints/entry_endpoint.rb
+++ b/lib/oxford_dictionary/endpoints/entry_endpoint.rb
@@ -1,11 +1,11 @@
-require 'oxford_dictionary/request'
+require 'oxford_dictionary/deprecated_request'
 require 'oxford_dictionary/api_objects/entry_response'
 
 module OxfordDictionary
   module Endpoints
     # Interface to '/entries' endpoint
     module EntryEndpoint
-      include OxfordDictionary::Request
+      include OxfordDictionary::DeprecatedRequest
       ENDPOINT = 'entries'.freeze
 
       def entry(query, params = {})

--- a/lib/oxford_dictionary/endpoints/inflection_endpoint.rb
+++ b/lib/oxford_dictionary/endpoints/inflection_endpoint.rb
@@ -1,11 +1,11 @@
-require 'oxford_dictionary/request'
+require 'oxford_dictionary/deprecated_request'
 require 'oxford_dictionary/api_objects/entry_response'
 
 module OxfordDictionary
   module Endpoints
     # Interface to '/inflections' endpoint
     module InflectionEndpoint
-      include OxfordDictionary::Request
+      include OxfordDictionary::DeprecatedRequest
       ENDPOINT = 'inflections'.freeze
 
       def inflection(query, params = {})

--- a/lib/oxford_dictionary/endpoints/search_endpoint.rb
+++ b/lib/oxford_dictionary/endpoints/search_endpoint.rb
@@ -1,11 +1,11 @@
-require 'oxford_dictionary/request'
+require 'oxford_dictionary/deprecated_request'
 require 'oxford_dictionary/api_objects/list_response'
 
 module OxfordDictionary
   module Endpoints
     # Interface to '/search' endpoint
     module SearchEndpoint
-      include OxfordDictionary::Request
+      include OxfordDictionary::DeprecatedRequest
       ENDPOINT = 'search'.freeze
 
       def search(query, params = {})

--- a/lib/oxford_dictionary/endpoints/wordlist_endpoint.rb
+++ b/lib/oxford_dictionary/endpoints/wordlist_endpoint.rb
@@ -1,12 +1,12 @@
-require 'oxford_dictionary/request'
+require 'oxford_dictionary/deprecated_request'
 require 'oxford_dictionary/api_objects/list_response'
 
 module OxfordDictionary
   module Endpoints
     # Interface to '/wordlist' endpoint
     module WordlistEndpoint
-      include OxfordDictionary::Request
       extend Gem::Deprecate
+      include OxfordDictionary::DeprecatedRequest
 
       ENDPOINT = 'wordlist'.freeze
       ADVANCED_FILTERS = [:exact, :exclude, :exclude_senses,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,7 @@ def fixture(file)
 end
 
 def api_url(path)
-  "#{OxfordDictionary::Request::BASE}/#{path}"
+  "#{OxfordDictionary::DeprecatedRequest::BASE}/#{path}"
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
So that we all know that this is changing in V2. There are a zillion
things in this approach that make everything complicated.