### PR TITLE
Cut 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## OxfordDictionary master (unreleased)
 
+## OxfordDictionary 1.1.0 (2019-06-22)
+
+- Add V2 entries support
+  [\#8](https://github.com/swcraig/oxford-dictionary/pull/8)
+
 ## OxfordDictionary 1.0.1 (2019-05-07)
 
 - Deprecate the Wordlist endpoint

--- a/lib/oxford_dictionary/version.rb
+++ b/lib/oxford_dictionary/version.rb
@@ -1,3 +1,3 @@
 module OxfordDictionary
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.1.0'.freeze
 end


### PR DESCRIPTION
V1 API support from Oxford Dictionaries will end on June 30, 2019:
https://developer.oxforddictionaries.com/version2

Current library uses will see deprecation warnings for the
`Client#entry` calls (until they upgrade to named parameters).

Reference https://github.com/swcraig/oxford-dictionary/pull/8 for more
information. The new interface is shown in
`OxfordDictionary::Endpoints::Entries`.