### PR TITLE
Add OxfordDictionary::Endpoints::Lemmas

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,4 @@ require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: [:spec, :rubocop]
-
-task :rubocop do
-  sh 'rubocop'
-end
+task default: [:spec]

--- a/fixtures/vcr_cassettes/lemmas_lemma-es.yml
+++ b/fixtures/vcr_cassettes/lemmas_lemma-es.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://od-api.oxforddictionaries.com/api/v2/lemmas/es/fuego
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Host:
+      - od-api.oxforddictionaries.com
+      App-Id:
+      - APP_ID
+      App-Key:
+      - APP_KEY
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Api-Version:
+      - v2
+      Code-Version:
+      - v2.3.2-g02aa52c
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sat, 22 Jun 2019 23:43:20 GMT
+      Server:
+      - openresty/1.13.6.2
+      Content-Length:
+      - '1429'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+            "metadata": {
+                "provider": "Oxford University Press"
+            },
+            "results": [
+                {
+                    "id": "fuego",
+                    "language": "es",
+                    "lexicalEntries": [
+                        {
+                            "grammaticalFeatures": [
+                                {
+                                    "id": "masculine",
+                                    "text": "Masculine",
+                                    "type": "Gender"
+                                }
+                            ],
+                            "inflectionOf": [
+                                {
+                                    "id": "fuego",
+                                    "text": "fuego"
+                                }
+                            ],
+                            "language": "es",
+                            "lexicalCategory": {
+                                "id": "noun",
+                                "text": "Noun"
+                            },
+                            "text": "fuego"
+                        },
+                        {
+                            "inflectionOf": [
+                                {
+                                    "id": "fuego",
+                                    "text": "fuego"
+                                }
+                            ],
+                            "language": "es",
+                            "lexicalCategory": {
+                                "id": "interjection",
+                                "text": "Interjection"
+                            },
+                            "text": "fuego"
+                        }
+                    ],
+                    "word": "fuego"
+                }
+            ]
+        }
+    http_version: 
+  recorded_at: Sat, 22 Jun 2019 23:43:20 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/lemmas_lemma-verbs.yml
+++ b/fixtures/vcr_cassettes/lemmas_lemma-verbs.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://od-api.oxforddictionaries.com/api/v2/lemmas/en/ace?lexicalCategory=verb
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Host:
+      - od-api.oxforddictionaries.com
+      App-Id:
+      - APP_ID
+      App-Key:
+      - APP_KEY
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Api-Version:
+      - v2
+      Code-Version:
+      - v2.3.2-g02aa52c
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sat, 22 Jun 2019 23:43:19 GMT
+      Server:
+      - openresty/1.13.6.2
+      Content-Length:
+      - '964'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+            "metadata": {
+                "provider": "Oxford University Press"
+            },
+            "results": [
+                {
+                    "id": "ace",
+                    "language": "en",
+                    "lexicalEntries": [
+                        {
+                            "grammaticalFeatures": [
+                                {
+                                    "id": "transitive",
+                                    "text": "Transitive",
+                                    "type": "Subcategorization"
+                                }
+                            ],
+                            "inflectionOf": [
+                                {
+                                    "id": "ace",
+                                    "text": "ace"
+                                }
+                            ],
+                            "language": "en",
+                            "lexicalCategory": {
+                                "id": "verb",
+                                "text": "Verb"
+                            },
+                            "text": "ace"
+                        }
+                    ],
+                    "word": "ace"
+                }
+            ]
+        }
+    http_version: 
+  recorded_at: Sat, 22 Jun 2019 23:43:19 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/lemmas_lemma.yml
+++ b/fixtures/vcr_cassettes/lemmas_lemma.yml
@@ -1,0 +1,109 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://od-api.oxforddictionaries.com/api/v2/lemmas/en/ace
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Host:
+      - od-api.oxforddictionaries.com
+      App-Id:
+      - APP_ID
+      App-Key:
+      - APP_KEY
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Api-Version:
+      - v2
+      Code-Version:
+      - v2.3.2-g02aa52c
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sat, 22 Jun 2019 23:42:51 GMT
+      Server:
+      - openresty/1.13.6.2
+      Content-Length:
+      - '1866'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+            "metadata": {
+                "provider": "Oxford University Press"
+            },
+            "results": [
+                {
+                    "id": "ace",
+                    "language": "en",
+                    "lexicalEntries": [
+                        {
+                            "inflectionOf": [
+                                {
+                                    "id": "ace",
+                                    "text": "ace"
+                                }
+                            ],
+                            "language": "en",
+                            "lexicalCategory": {
+                                "id": "noun",
+                                "text": "Noun"
+                            },
+                            "text": "ace"
+                        },
+                        {
+                            "inflectionOf": [
+                                {
+                                    "id": "ace",
+                                    "text": "ace"
+                                }
+                            ],
+                            "language": "en",
+                            "lexicalCategory": {
+                                "id": "adjective",
+                                "text": "Adjective"
+                            },
+                            "text": "ace"
+                        },
+                        {
+                            "grammaticalFeatures": [
+                                {
+                                    "id": "transitive",
+                                    "text": "Transitive",
+                                    "type": "Subcategorization"
+                                }
+                            ],
+                            "inflectionOf": [
+                                {
+                                    "id": "ace",
+                                    "text": "ace"
+                                }
+                            ],
+                            "language": "en",
+                            "lexicalCategory": {
+                                "id": "verb",
+                                "text": "Verb"
+                            },
+                            "text": "ace"
+                        }
+                    ],
+                    "word": "ace"
+                }
+            ]
+        }
+    http_version: 
+  recorded_at: Sat, 22 Jun 2019 23:42:51 GMT
+recorded_with: VCR 4.0.0

--- a/lib/oxford_dictionary/client.rb
+++ b/lib/oxford_dictionary/client.rb
@@ -3,6 +3,7 @@ require 'oxford_dictionary/endpoints/inflection_endpoint'
 require 'oxford_dictionary/endpoints/search_endpoint'
 require 'oxford_dictionary/endpoints/wordlist_endpoint'
 
+require 'oxford_dictionary/endpoints/entries'
 require 'oxford_dictionary/endpoints/lemmas'
 
 module OxfordDictionary

--- a/lib/oxford_dictionary/client.rb
+++ b/lib/oxford_dictionary/client.rb
@@ -3,6 +3,8 @@ require 'oxford_dictionary/endpoints/inflection_endpoint'
 require 'oxford_dictionary/endpoints/search_endpoint'
 require 'oxford_dictionary/endpoints/wordlist_endpoint'
 
+require 'oxford_dictionary/endpoints/lemmas'
+
 module OxfordDictionary
   # The client object to interact with
   class Client
@@ -49,7 +51,16 @@ module OxfordDictionary
         entry_snake_case(word: word, dataset: dataset, params: params)
     end
 
+    def lemma(word:, language:, params: {})
+      lemma_endpoint.lemma(word: word, language: language, params: params)
+    end
+
     private
+
+    def lemma_endpoint
+      @lemma_endpoint ||=
+        OxfordDictionary::Endpoints::Lemmas.new(request_client: request_client)
+    end
 
     def entry_endpoint
       @entry_endpoint ||=

--- a/lib/oxford_dictionary/endpoints/inflection_endpoint.rb
+++ b/lib/oxford_dictionary/endpoints/inflection_endpoint.rb
@@ -9,6 +9,13 @@ module OxfordDictionary
       ENDPOINT = 'inflections'.freeze
 
       def inflection(query, params = {})
+        warn '''
+          Client#inflection is DEPRECATED and will become non-functional
+          on June 30, 2019. Use Client#lemma instead. Reference
+          github.com/swcraig/oxford-dictionary/pull/10 for for more information.
+          Check out OxfordDictionary::Endpoints::Lemmas#lemma for the interface
+          to use.
+        '''
         EntryResponse.new(request(ENDPOINT, query, params)['results'][0])
       end
     end

--- a/lib/oxford_dictionary/endpoints/lemmas.rb
+++ b/lib/oxford_dictionary/endpoints/lemmas.rb
@@ -1,0 +1,31 @@
+require 'oxford_dictionary/deserialize'
+
+module OxfordDictionary
+  module Endpoints
+    class Lemmas
+      ENDPOINT = 'lemmas'.freeze
+
+      def initialize(request_client:)
+        @request_client = request_client
+      end
+
+      def lemma(word:, language:, params: {})
+        query_string = "#{ENDPOINT}/#{language}/#{word}"
+        uri = URI(query_string)
+
+        unless params.empty?
+          uri.query = URI.encode_www_form(params)
+        end
+
+        response = @request_client.get(uri: uri)
+        deserialize.call(response.body)
+      end
+
+      private
+
+      def deserialize
+        @deserialize ||= OxfordDictionary::Deserialize.new
+      end
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.describe OxfordDictionary::Client do
   let(:app_id) { 'ID' }
   let(:app_key) { 'KEY' }
+  let(:client) { described_class.new(app_id: app_id, app_key: app_key) }
 
   describe '#new' do
     it 'requires an argument' do
@@ -22,7 +23,6 @@ RSpec.describe OxfordDictionary::Client do
   end
 
   describe '#entry' do
-    let(:client) { described_class.new(app_id: app_id, app_key: app_key) }
     subject { client.entry(args) }
 
     context 'when the argument is a Hash' do
@@ -35,6 +35,21 @@ RSpec.describe OxfordDictionary::Client do
 
         subject
       end
+    end
+  end
+
+  describe '#lemma' do
+    subject { client.lemma(word: word, language: language, params: params) }
+    let(:word) { 'ace' }
+    let(:language) { 'en' }
+    let(:params) { {} }
+
+    it 'calls the Lemmas endpoint with correct arguments' do
+      expect_any_instance_of(OxfordDictionary::Endpoints::Lemmas).
+        to receive(:lemma).
+        with(word: word, language: language, params: params)
+
+      subject
     end
   end
 

--- a/spec/endpoints/lemmas_spec.rb
+++ b/spec/endpoints/lemmas_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'oxford_dictionary/endpoints/lemmas'
+
+# Spec dependencies
+require 'oxford_dictionary/request'
+
+RSpec.describe OxfordDictionary::Endpoints::Lemmas do
+  let(:request_client) do
+    OxfordDictionary::Request.
+      new(app_id: ENV['APP_ID'], app_key: ENV['APP_KEY'])
+  end
+
+  let(:endpoint) { described_class.new(request_client: request_client) }
+
+  let(:word) { 'ace' }
+  let(:language) { 'en' }
+  let(:params) { {} }
+
+  describe '#lemma' do
+    subject { endpoint.lemma(word: word, language: language, params: params) }
+
+    it 'calls API as expected', :aggregate_failures do
+      expect(request_client).to receive(:get).
+        with(uri: URI("lemmas/#{language}/#{word}")).and_call_original
+
+      VCR.use_cassette('lemmas#lemma') do
+        response = subject
+        expect(response).to be_an(OpenStruct)
+        expect(response.results.first.id).to eq(word)
+        expect(response.results.first.lexicalEntries).to all(be_an(OpenStruct))
+      end
+    end
+
+    context 'when the params include lexicalCategory: verb' do
+      let(:params) { { lexicalCategory: 'verb' } }
+
+      it 'only returns lemmas that are verbs', :aggregate_failures do
+        expect(request_client).to receive(:get).
+          with(uri: URI("lemmas/#{language}/#{word}?lexicalCategory=verb")).
+          and_call_original
+
+        VCR.use_cassette('lemmas#lemma-verbs') do
+          response = subject
+
+          lexical_entries = response.results.first.lexicalEntries
+          lexical_categories =
+            lexical_entries.map { |entry| entry.lexicalCategory.id }.uniq
+
+          expect(response).to be_an(OpenStruct)
+          expect(response.results.first.id).to eq(word)
+          expect(response.results.first.lexicalEntries).
+            to all(be_an(OpenStruct))
+          expect(lexical_categories.length).to eq(1)
+        end
+      end
+    end
+
+    context "when the language is es" do
+      let(:word) { 'fuego' }
+      let(:language) { 'es' }
+
+      it 'calls the API with en-us in the URL', :aggregate_failures do
+        expect(request_client).to receive(:get).
+          with(uri: URI("lemmas/#{language}/#{word}")).
+          and_call_original
+
+        VCR.use_cassette('lemmas#lemma-es') do
+          response = subject
+          expect(response).to be_an(OpenStruct)
+          expect(response.results.first.id).to eq(word)
+          expect(response.results.first.lexicalEntries).
+            to all(be_an(OpenStruct))
+          expect(response.results.first.language).to eq(language)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Oxford Dictionaries is replacing the inflections endpoint from V1 with
this new endpoint (so that it more accurately describes what the
endpoint is returning).

https://developer.oxforddictionaries.com/version2

The V1 interface (for inflections) will become non-functional on June 30,
2019.