### PR TITLE
Add OxfordDictionary::Endpoints::Thesaurus

### DIFF
--- a/lib/oxford_dictionary/client.rb
+++ b/lib/oxford_dictionary/client.rb
@@ -7,6 +7,7 @@ require 'oxford_dictionary/endpoints/entries'
 require 'oxford_dictionary/endpoints/lemmas'
 require 'oxford_dictionary/endpoints/translations'
 require 'oxford_dictionary/endpoints/sentences'
+require 'oxford_dictionary/endpoints/thesaurus'
 
 module OxfordDictionary
   # The client object to interact with
@@ -71,6 +72,14 @@ module OxfordDictionary
       sentence_endpoint.sentence(word: word, language: language, params: params)
     end
 
+    def thesaurus(word:, language:, params: {})
+      thesaurus_endpoint.thesaurus(
+        word: word,
+        language: language,
+        params: params
+      )
+    end
+
     private
 
     def lemma_endpoint
@@ -91,6 +100,12 @@ module OxfordDictionary
 
     def sentence_endpoint
       @sentence_endpoint ||= OxfordDictionary::Endpoints::Sentences.new(
+        request_client: request_client
+      )
+    end
+
+    def thesaurus_endpoint
+      @thesaurus_endpoint ||= OxfordDictionary::Endpoints::Thesaurus.new(
         request_client: request_client
       )
     end

--- a/lib/oxford_dictionary/endpoints/entry_endpoint.rb
+++ b/lib/oxford_dictionary/endpoints/entry_endpoint.rb
@@ -41,16 +41,43 @@ module OxfordDictionary
       end
 
       def entry_antonyms(query, params = {})
+        warn '''
+        Client#entry_antonyms is DEPRECATED and will become non-functional
+        on June 30, 2019. Use Client#thesaurus instead. Reference
+        https://github.com/swcraig/oxford-dictionary/pull/13 for more
+        information. Check out OxfordDictionary::Endpoints::Thesaurus for the
+        interface to use. Specifically use it with
+        params: { fields: \'antonyms\' }
+        '''
+
         params[:end] = 'antonyms'
         entry_request(query, params)
       end
 
       def entry_synonyms(query, params = {})
+        warn '''
+        Client#entry_synonyms is DEPRECATED and will become non-functional
+        on June 30, 2019. Use Client#thesaurus instead. Reference
+        https://github.com/swcraig/oxford-dictionary/pull/13 for more
+        information. Check out OxfordDictionary::Endpoints::Thesaurus for the
+        interface to use. Specifically use it with
+        params: { fields: \'synonyms\' }
+        '''
+
         params[:end] = 'synonyms'
         entry_request(query, params)
       end
 
       def entry_antonyms_synonyms(query, params = {})
+        warn '''
+        Client#entry_antonyms_synonyms is DEPRECATED and will be non-functional
+        on June 30, 2019. Use Client#thesaurus instead. Reference
+        https://github.com/swcraig/oxford-dictionary/pull/14 for more
+        information. Check out OxfordDictionary::Endpoints::Thesaurus for the
+        interface to use. Specifically use it with
+        params: { fields: \'synonyms,antonyms\' }
+        '''
+
         params[:end] = 'synonyms;antonyms'
         entry_request(query, params)
       end

--- a/lib/oxford_dictionary/endpoints/thesaurus.rb
+++ b/lib/oxford_dictionary/endpoints/thesaurus.rb
@@ -1,0 +1,21 @@
+require 'oxford_dictionary/endpoints/endpoint'
+
+module OxfordDictionary
+  module Endpoints
+    class Thesaurus < Endpoint
+      ENDPOINT = 'thesaurus'.freeze
+
+      def thesaurus(word:, language:, params: {})
+        query_string = "#{ENDPOINT}/#{language}/#{word}"
+        uri = URI(query_string)
+
+        unless params.empty?
+          uri.query = URI.encode_www_form(params)
+        end
+
+        response = @request_client.get(uri: uri)
+        deserialize.call(response.body)
+      end
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe OxfordDictionary::Client do
     end
   end
 
+  describe '#thesaurus' do
+    subject { client.thesaurus(word: word, language: language, params: params) }
+    let(:word) { 'ace' }
+    let(:language) { 'en' }
+    let(:params) { {} }
+
+    it 'calls the Thesaurus endpoint with correct arguments' do
+      expect_any_instance_of(OxfordDictionary::Endpoints::Thesaurus).
+        to receive(:thesaurus).
+        with(word: word, language: language, params: params)
+
+      subject
+    end
+  end
+
   describe '#entry_snake_case' do
     let(:client) { described_class.new(app_id: app_id, app_key: app_key) }
     subject do

--- a/spec/endpoints/thesaurus_spec.rb
+++ b/spec/endpoints/thesaurus_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'oxford_dictionary/endpoints/thesaurus'
+
+# Spec dependencies
+require 'oxford_dictionary/request'
+
+RSpec.describe OxfordDictionary::Endpoints::Thesaurus do
+  let(:request_client) do
+    OxfordDictionary::Request.
+      new(app_id: ENV['APP_ID'], app_key: ENV['APP_KEY'])
+  end
+
+  let(:endpoint) { described_class.new(request_client: request_client) }
+
+  let(:word) { 'ace' }
+  let(:language) { 'en' }
+  let(:params) { { fields: 'synonyms,antonyms' } }
+
+  # The sentences endpoint is only avaiable to the paid tier
+  # If someone with a paid tier account would like to contribute, please
+  # feel free remove this double (and the stub in the tests), uncomment the
+  # sections that run VCR against the live endpoint, and PR the resulting files
+  let(:response_double) { double(body: {}.to_json) }
+
+  describe '#thesaurus' do
+    subject do
+      endpoint.thesaurus(word: word, language: language, params: params)
+    end
+
+    it 'calls API as expected', :aggregate_failures do
+      expected_uri =
+        URI("thesaurus/#{language}/#{word}?fields=synonyms%2Cantonyms")
+
+      expect(request_client).to receive(:get).
+        with(uri: expected_uri).
+        and_return(response_double)
+
+      subject
+
+      # VCR.use_cassette('sentences#sentence') do
+      #   response = subject
+      #   expect(response).to be_an(OpenStruct)
+      #   expect(response.results.first.id).to eq(word)
+      #   expect(response.results.first.lexicalEntries).to all(be_an(OpenStruct))
+      # end
+    end
+  end
+end


### PR DESCRIPTION
Oxford Dictionaries is updating their API to a new version which
includes quite a few changes:
https://developer.oxforddictionaries.com/version2

They are moving the thesaurus functionality to its own endpoint
(instead of having part of the entries endpoint).

Use `Client#thesaurus` instead. Specifically use `Client#thesaurus` with
the `filter` parameter to define what you want.

For example:

```
Client.thesaurus(
  word: 'ace',
  language: 'en',
  params: { filter: 'synonyms,antonyms' }
)

```

Or to get just the synonyms/antonyms:

```
Client.thesaurus(
  word: 'ace',
  language: 'en',
  params: { filter: 'synonyms' }
)
```