### PR TITLE
Add OxfordDictionary::Endpoints::Search

### DIFF
--- a/lib/oxford_dictionary/client.rb
+++ b/lib/oxford_dictionary/client.rb
@@ -8,6 +8,7 @@ require 'oxford_dictionary/endpoints/lemmas'
 require 'oxford_dictionary/endpoints/translations'
 require 'oxford_dictionary/endpoints/sentences'
 require 'oxford_dictionary/endpoints/thesaurus'
+require 'oxford_dictionary/endpoints/search'
 
 module OxfordDictionary
   # The client object to interact with
@@ -80,6 +81,36 @@ module OxfordDictionary
       )
     end
 
+    def search(*args)
+      if args.first.is_a?(Hash)
+        args = args.first
+        search_endpoint.search(language: args[:language], params: args[:params])
+      else
+        warn '''
+          Client#search without parameters is DEPRECATED.
+          Using the method without named parameters will become
+          non-functional on June 30, 2019. Use the new V2 interface for this
+          method instead. Reference github.com/swcraig/oxford-dictionary/pull/15
+          for more information. Specifically check out
+          OxfordDictionary::Endpoints::Search#search for the new interface.
+        '''
+        if args[1].is_a?(Hash) && args[1][:translations]
+          super(args[0], translations: args[1][:translations])
+        else
+          super(*args)
+        end
+      end
+    end
+
+    def search_translation(source_language:, target_language:, params: {})
+      search_endpoint.search_translation(
+        source_language: source_language,
+        target_language: target_language,
+        params: params
+      )
+    end
+
+
     private
 
     def lemma_endpoint
@@ -100,6 +131,12 @@ module OxfordDictionary
 
     def sentence_endpoint
       @sentence_endpoint ||= OxfordDictionary::Endpoints::Sentences.new(
+        request_client: request_client
+      )
+    end
+
+    def search_endpoint
+      @search_endpoint ||= OxfordDictionary::Endpoints::Search.new(
         request_client: request_client
       )
     end

--- a/lib/oxford_dictionary/endpoints/search.rb
+++ b/lib/oxford_dictionary/endpoints/search.rb
@@ -1,0 +1,34 @@
+require 'oxford_dictionary/endpoints/endpoint'
+
+module OxfordDictionary
+  module Endpoints
+    class Search < Endpoint
+      ENDPOINT = 'search'.freeze
+
+      def search(language:, params: {})
+        query_string = "#{ENDPOINT}/#{language}"
+        uri = URI(query_string)
+
+        unless params.empty?
+          uri.query = URI.encode_www_form(params)
+        end
+
+        response = @request_client.get(uri: uri)
+        deserialize.call(response.body)
+      end
+
+      def search_translation(source_language:, target_language:, params: {})
+        query_string =
+          "#{ENDPOINT}/translations/#{source_language}/#{target_language}"
+        uri = URI(query_string)
+
+        unless params.empty?
+          uri.query = URI.encode_www_form(params)
+        end
+
+        response = @request_client.get(uri: uri)
+        deserialize.call(response.body)
+      end
+    end
+  end
+end

--- a/lib/oxford_dictionary/endpoints/search_endpoint.rb
+++ b/lib/oxford_dictionary/endpoints/search_endpoint.rb
@@ -9,6 +9,15 @@ module OxfordDictionary
       ENDPOINT = 'search'.freeze
 
       def search(query, params = {})
+        warn '''
+        Client#search without using named parameters is DEPRECATED and will
+        become non-functional on June 30, 2019 (it uses the V1 interface which
+        Oxford Dictionaries is taking offline). Reference
+        https://github.com/swcraig/oxford-dictionary/pull/15 for more
+        information. Check out OxfordDictionary::Endpoints::Search for the
+        interface to use.
+        '''
+
         params[:q] = query
         ListResponse.new(request(ENDPOINT, query, params))
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -109,6 +109,43 @@ RSpec.describe OxfordDictionary::Client do
     end
   end
 
+  describe '#search' do
+    subject { client.search(language: language, params: params) }
+    let(:language) { 'en' }
+    let(:params) { { q: 'an' } }
+
+    it 'calls the Search endpoint with correct arguments' do
+      expect_any_instance_of(OxfordDictionary::Endpoints::Search).
+        to receive(:search).
+        with(language: language, params: params)
+
+      subject
+    end
+  end
+
+  describe '#search_translation' do
+    subject do
+      client.search_translation(
+        source_language: source_language,
+        target_language: target_language,
+        params: params
+      )
+    end
+    let(:source_language) { 'en' }
+    let(:target_language) { 'es' }
+    let(:params) { {} }
+
+    it 'calls the Search endpoint with correct arguments' do
+      expect_any_instance_of(OxfordDictionary::Endpoints::Search).
+        to receive(:search_translation).
+        with(source_language: source_language,
+             target_language: target_language,
+             params: params)
+
+      subject
+    end
+  end
+
   describe '#entry_snake_case' do
     let(:client) { described_class.new(app_id: app_id, app_key: app_key) }
     subject do

--- a/spec/endpoints/search_spec.rb
+++ b/spec/endpoints/search_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+require 'oxford_dictionary/endpoints/search'
+
+# Spec dependencies
+require 'oxford_dictionary/request'
+
+RSpec.describe OxfordDictionary::Endpoints::Search do
+  let(:request_client) do
+    OxfordDictionary::Request.
+      new(app_id: ENV['APP_ID'], app_key: ENV['APP_KEY'])
+  end
+
+  let(:endpoint) { described_class.new(request_client: request_client) }
+
+  # The search endpoint is only avaiable to the paid tier
+  # If someone with a paid tier account would like to contribute, please
+  # feel free remove this double (and the stub in the tests), uncomment the
+  # sections that run VCR against the live endpoint, and PR the resulting files
+  let(:response_double) { double(body: {}.to_json) }
+
+  describe '#search' do
+    subject do
+      endpoint.search(language: language, params: params)
+    end
+
+    let(:language) { 'en-gb' }
+    let(:params) { { q: 'an' } }
+
+
+    it 'calls API as expected', :aggregate_failures do
+      expected_uri = URI("search/#{language}?q=an")
+
+      expect(request_client).to receive(:get).
+        with(uri: expected_uri).
+        and_return(response_double)
+
+      subject
+
+      # VCR.use_cassette('search#search') do
+      #   response = subject
+      #   expect(response).to be_an(OpenStruct)
+      #   expect(response.results.first.id).to eq(word)
+      #   expect(response.results.first.lexicalEntries).to all(be_an(OpenStruct))
+      # end
+    end
+  end
+
+  describe '#search_translation' do
+    subject do
+      endpoint.search_translation(
+        source_language: source_language,
+        target_language: target_language,
+        params: params
+      )
+    end
+
+    let(:source_language) { 'en' }
+    let(:target_language) { 'es' }
+    let(:params) { { q: 'an' } }
+
+    it 'calls API as expected', :aggregate_failures do
+      expected_uri =
+        URI("search/translations/#{source_language}/#{target_language}?q=an")
+
+      expect(request_client).to receive(:get).
+        with(uri: expected_uri).
+        and_return(response_double)
+
+      subject
+
+      # VCR.use_cassette('search#search_translation') do
+      #   response = subject
+      #   expect(response).to be_an(OpenStruct)
+      #   expect(response.results.first.id).to eq(word)
+      #   expect(response.results.first.lexicalEntries).to all(be_an(OpenStruct))
+      # end
+    end
+  end
+end


### PR DESCRIPTION
Oxford Dictionaries is updating their API to a new version which
includes quite a few changes:
https://developer.oxforddictionaries.com/version2

There have been updates to the search functionality which is documented
in the migration guide linked above.

I've tried to be smart and preserve the interface so that users can
upgrade to V2 without any immediate breaking changes (as long as the
V1 usage was what was documented in the README).

Check out `OxfordDictionary::Endpoints::Search#search` for how to use
the new interface which uses named parameters.