### PR TITLE
Cut 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## OxfordDictionary master (unreleased)
 
+## OxfordDictionary 1.3.0 (2019-06-22)
+
+- Add V2 translations support
+  [\#10](https://github.com/swcraig/oxford-dictionary/pull/12)
+- Add V2 sentences support
+  [\#10](https://github.com/swcraig/oxford-dictionary/pull/13)
+- Add V2 thesaurus support
+  [\#10](https://github.com/swcraig/oxford-dictionary/pull/14)
+- Add V2 search support
+  [\#10](https://github.com/swcraig/oxford-dictionary/pull/15)
+
 ## OxfordDictionary 1.2.0 (2019-06-22)
 
 - Add V2 lemmas support

--- a/lib/oxford_dictionary/version.rb
+++ b/lib/oxford_dictionary/version.rb
@@ -1,3 +1,3 @@
 module OxfordDictionary
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.3.0'.freeze
 end


### PR DESCRIPTION
Oxford Dictionaries is updating their API to a new version which
includes quite a few changes:
https://developer.oxforddictionaries.com/version2

Oxford Dictionaries is taking their V1 API offline on June 30, 2019.

The deprecation warnings (please check the closed PRs online which
include them) should give an idea on how users should update their
applications to use the new V2 interfaces. All V2 interfaces use named
parameters and specifically leverage their `params` arguments for more
control over how the endpoints are called. Check out [Oxford
Dictionaries' online documentation]
(https://developer.oxforddictionaries.com/documentation), the specs, and
the commit messages for the V2 endpoints for more information.

v1.3.0 does not include a README update (I will do that when I cut
v2.0.0).

The 2.0.0 of this library will include the removal of all V1 interfaces.

The V2 interfaces for this library are in the following PRs:
Entries: https://github.com/swcraig/oxford-dictionary/pull/8
Translations: https://github.com/swcraig/oxford-dictionary/pull/12
Sentences: https://github.com/swcraig/oxford-dictionary/pull/13
Thesaurus: https://github.com/swcraig/oxford-dictionary/pull/14
Lemmas: https://github.com/swcraig/oxford-dictionary/pull/10
Search: https://github.com/swcraig/oxford-dictionary/pull/15