### PR TITLE
adds import for Oxford::Request to avoid NameError when using in a Rails Project

### DIFF
--- a/lib/oxford_dictionary/client.rb
+++ b/lib/oxford_dictionary/client.rb
@@ -10,6 +10,8 @@ require 'oxford_dictionary/endpoints/sentences'
 require 'oxford_dictionary/endpoints/thesaurus'
 require 'oxford_dictionary/endpoints/search'
 
+require 'oxford_dictionary/request'
+
 module OxfordDictionary
   # The client object to interact with
   class Client

--- a/lib/oxford_dictionary/version.rb
+++ b/lib/oxford_dictionary/version.rb
@@ -1,3 +1,3 @@
 module OxfordDictionary
-  VERSION = '1.3.0'.freeze
+  VERSION = '1.3.1'.freeze
 end


### PR DESCRIPTION
Removes the `<NameError: uninitialized constant OxfordDictionary::Request>` that was happening when using version 1.3.0 of the gem in a Rails project by adding a `require` statement for that class to the Client.