### PR TITLE
Cut 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## OxfordDictionary master (unreleased)
 
+## OxfordDictionary 2.0.0 (2019-06-29)
+- Remove wordlist endpoint
+  [\#20](https://github.com/swcraig/oxford-dictionary/pull/20)
+- Use new V2 interface for V1 inflection usage
+  [\#21](https://github.com/swcraig/oxford-dictionary/pull/21)
+- Use new V2 interface for V1 search usage
+  [\#22](https://github.com/swcraig/oxford-dictionary/pull/22)
+- Use new V2 interface for V1 entry usage
+  [\#23](https://github.com/swcraig/oxford-dictionary/pull/23)
+- Remove all V1 functionality
+  [\#24](https://github.com/swcraig/oxford-dictionary/pull/24)
+
 ## OxfordDictionary 1.3.0 (2019-06-22)
 
 - Add V2 translations support

--- a/lib/oxford_dictionary/version.rb
+++ b/lib/oxford_dictionary/version.rb
@@ -1,3 +1,3 @@
 module OxfordDictionary
-  VERSION = '1.3.1'.freeze
+  VERSION = '2.0.0'.freeze
 end


### PR DESCRIPTION
Oxford Dictionaries has made a V2 upgrade to their API and will be
taking their V1 API offline on June 30, 2019.

Reference the README and following PRs for the new usage:
- Entries: https://github.com/swcraig/oxford-dictionary/pull/8
- Translations: https://github.com/swcraig/oxford-dictionary/pull/12
- Sentences: https://github.com/swcraig/oxford-dictionary/pull/13
- Thesaurus: https://github.com/swcraig/oxford-dictionary/pull/14
- Lemmas: https://github.com/swcraig/oxford-dictionary/pull/10
- Search: https://github.com/swcraig/oxford-dictionary/pull/15

This version uses the V2 endpoints exclusively.