### PR TITLE
Add RuboCop as part of default rake task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+Lint/ImplicitStringConcatenation:
+  Enabled: false
+
+Style/DotPosition:
+  EnforcedStyle: trailing

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,8 @@ require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: [:spec]
+task default: [:spec, :rubocop]
+
+task :rubocop do
+  sh 'rubocop'
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe OxfordDictionary::Client do
 
   describe '#new' do
     it 'requires an argument' do
-      expect { OxfordDictionary::Client.new(nil) }
-        .to raise_error(ArgumentError, 'API id and key required.')
+      expect { OxfordDictionary::Client.new(nil) }.
+        to raise_error(ArgumentError, 'API id and key required.')
     end
 
     it 'requires a hash argument' do
-      expect { OxfordDictionary::Client.new('string') }
-        .to raise_error(ArgumentError, 'API id and key required.')
+      expect { OxfordDictionary::Client.new('string') }.
+        to raise_error(ArgumentError, 'API id and key required.')
     end
 
     it 'requires both id and key' do
-      expect { OxfordDictionary.new(app_id: 'ID') }
-        .to raise_error(ArgumentError, 'API id and key required.')
+      expect { OxfordDictionary.new(app_id: 'ID') }.
+        to raise_error(ArgumentError, 'API id and key required.')
     end
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe OxfordDictionary::Client do
       it 'calls the Entries endpoint with correct arguments' do
         expect_any_instance_of(OxfordDictionary::Endpoints::Entries).
           to receive(:entry).
-          with(word: args[:word], dataset: args[:dataset], params: args[:params])
+          with(word: args[:word],
+               dataset: args[:dataset],
+               params: args[:params])
 
         subject
       end
@@ -59,7 +61,8 @@ RSpec.describe OxfordDictionary::Client do
         word: word,
         source_language: source_language,
         target_language: target_language,
-        params: params)
+        params: params
+      )
     end
 
     let(:word) { 'ace' }

--- a/spec/endpoints/entries_spec.rb
+++ b/spec/endpoints/entries_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe OxfordDictionary::Endpoints::Entries do
       end
     end
 
-    context "when the dataset is en-us" do
+    context 'when the dataset is en-us' do
       let(:dataset) { 'en-us' }
 
       it 'calls the API with en-us in the URL' do

--- a/spec/endpoints/lemmas_spec.rb
+++ b/spec/endpoints/lemmas_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe OxfordDictionary::Endpoints::Lemmas do
       end
     end
 
-    context "when the language is es" do
+    context 'when the language is es' do
       let(:word) { 'fuego' }
       let(:language) { 'es' }
 

--- a/spec/endpoints/search_spec.rb
+++ b/spec/endpoints/search_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe OxfordDictionary::Endpoints::Search do
     let(:language) { 'en-gb' }
     let(:params) { { q: 'an' } }
 
-
     it 'calls API as expected', :aggregate_failures do
       expected_uri = URI("search/#{language}?q=an")
 
@@ -40,7 +39,8 @@ RSpec.describe OxfordDictionary::Endpoints::Search do
       #   response = subject
       #   expect(response).to be_an(OpenStruct)
       #   expect(response.results.first.id).to eq(word)
-      #   expect(response.results.first.lexicalEntries).to all(be_an(OpenStruct))
+      #   expect(response.results.first.lexicalEntries).
+      #     to all(be_an(OpenStruct))
       # end
     end
   end
@@ -72,7 +72,8 @@ RSpec.describe OxfordDictionary::Endpoints::Search do
       #   response = subject
       #   expect(response).to be_an(OpenStruct)
       #   expect(response.results.first.id).to eq(word)
-      #   expect(response.results.first.lexicalEntries).to all(be_an(OpenStruct))
+      #   expect(response.results.first.lexicalEntries).
+      #     to all(be_an(OpenStruct))
       # end
     end
   end

--- a/spec/endpoints/sentences_spec.rb
+++ b/spec/endpoints/sentences_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe OxfordDictionary::Endpoints::Sentences do
       #   response = subject
       #   expect(response).to be_an(OpenStruct)
       #   expect(response.results.first.id).to eq(word)
-      #   expect(response.results.first.lexicalEntries).to all(be_an(OpenStruct))
+      #   expect(response.results.first.lexicalEntries).
+      #     to all(be_an(OpenStruct))
       # end
     end
   end

--- a/spec/endpoints/thesaurus_spec.rb
+++ b/spec/endpoints/thesaurus_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe OxfordDictionary::Endpoints::Thesaurus do
       #   response = subject
       #   expect(response).to be_an(OpenStruct)
       #   expect(response.results.first.id).to eq(word)
-      #   expect(response.results.first.lexicalEntries).to all(be_an(OpenStruct))
+      #   expect(response.results.first.lexicalEntries).
+      #     to all(be_an(OpenStruct))
       # end
     end
   end

--- a/spec/endpoints/translations_spec.rb
+++ b/spec/endpoints/translations_spec.rb
@@ -47,16 +47,19 @@ RSpec.describe OxfordDictionary::Endpoints::Translations do
       #   response = subject
       #   expect(response).to be_an(OpenStruct)
       #   expect(response.results.first.id).to eq(word)
-      #   expect(response.results.first.lexicalEntries).to all(be_an(OpenStruct))
+      #   expect(response.results.first.lexicalEntries).
+      #     to all(be_an(OpenStruct))
       # end
     end
 
     context 'when the params include strictMatch: true' do
       let(:params) { { strictMatch: true } }
+      let(:strict) { 'strictMatch=true' }
 
       it 'only returns strict match translations', :aggregate_failures do
-        expected_uri =
-          URI("translations/#{source_language}/#{target_language}/#{word}?strictMatch=true")
+        expected_uri = URI(
+          "translations/#{source_language}/#{target_language}/#{word}?#{strict}"
+        )
 
         expect(request_client).to receive(:get).
           with(uri: expected_uri).

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,8 +7,8 @@ require 'vcr'
 VCR.configure do |config|
   config.cassette_library_dir = 'fixtures/vcr_cassettes'
   config.hook_into :webmock
-  config.filter_sensitive_data('APP_ID') { |request| ENV['APP_ID'] }
-  config.filter_sensitive_data('APP_KEY') { |request| ENV['APP_KEY'] }
+  config.filter_sensitive_data('APP_ID') { ENV['APP_ID'] }
+  config.filter_sensitive_data('APP_KEY') { ENV['APP_KEY'] }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
So that when we run `bundle exec rake` we also check for RuboCop offences.

I'll update the RuboCop version incrementally over time.