### PR TITLE
Cut 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## OxfordDictionary master (unreleased)
 
+## OxfordDictionary 3.0.0 (2019-08-13)
+- Remove support for all V1 API calls
+
 ## OxfordDictionary 2.0.0 (2019-06-29)
 - Remove wordlist endpoint
   [\#20](https://github.com/swcraig/oxford-dictionary/pull/20)

--- a/lib/oxford_dictionary/version.rb
+++ b/lib/oxford_dictionary/version.rb
@@ -1,3 +1,3 @@
 module OxfordDictionary
-  VERSION = '2.0.1'.freeze
+  VERSION = '3.0.0'.freeze
 end


### PR DESCRIPTION
All V1 API calls that were deprecated have been entirely removed.

See the CHANGELOG for relevant PRs.